### PR TITLE
Thermostat device settings added: Introducing "HVAC Eco mode override"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ You can use this app to:
 - Use HVAC _(Heating, Ventilating, and Air Conditioning)_ in your Flows:
     - HVAC state _(actively heating, actively cooling or not active)_ trigger and condition;
     - HVAC mode _(heating mode, cooling mode, heating and cooling mode, eco mode or system is off)_ trigger, condition and action.
+- If set in a thermostat's device settings: Homey can override that thermostat's eco HVAC mode to regain control of the target temperature.

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.nest",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "compatibility": ">=1.0.0",
   "name": {
     "en": "Nest",
@@ -96,7 +96,67 @@
           "id": "add_nest_thermostats",
           "template": "add_devices"
         }
-      ]
+      ],
+	  "settings": [
+		{
+		  "type": "group",
+		  "label": {
+			"en": "HVAC Eco mode override",
+			"nl": "HVAC Eco modus overschrijven"
+		  },
+		  "children": [
+			{
+			  "id": "eco_override_allow",
+			  "type": "checkbox",
+			  "value": false,
+			  "label": {
+				"en": "Allow HVAC Eco mode override?",
+				"nl": "HVAC Eco modus overschrijven toestaan?"
+			  },
+			  "hint": {
+				"en": "If HVAC Eco Mode is active, setting a target temperature is not allowed.\n\nIf HVAC Eco Mode is active, can it be overridden so that the temperature can still be set?",
+				"nl": "Indien HVAC Eco modus actief is, is het instellen van een doel temperatuur niet toegestaan.\n\nIndien HVAC Eco modus actief is, kan deze dan vooraf worden overschreven zodat de temperatuur toch kan worden ingesteld?"
+			  }
+			},
+			{
+			  "id": "eco_override_by",
+			  "type": "dropdown",
+			  "value": "heat",
+			  "label": {
+				"en": "Always override with mode",
+				"nl": "Altijd overschrijven met modus"
+			  },
+			  "hint": {
+				"en": "Caution: All HVAC modes are displayed, but thermostat settings may not support some modes!",
+				"nl": "Let op: alle HVAC modi worden weergegeven, maar thermostaat instellingen ondersteunen wellicht sommige modi niet!"
+			  },
+			  "values": [
+				{
+				  "id": "heat",
+				  "label": {
+					"en": "Heat",
+					"nl": "Verwarm"
+				  }
+				},
+				{
+				  "id": "cool",
+				  "label": {
+					"en": "Cool",
+					"nl": "Koel"
+				  }
+				},
+				{
+				  "id": "heat-cool",
+				  "label": {
+					"en": "Heating and cooling",
+					"nl": "Verwarm en koel"
+				  }
+				}
+			  ]
+			}
+		  ]
+		}
+	  ]
     },
     {
       "id": "nest_protect",

--- a/app.json
+++ b/app.json
@@ -110,12 +110,12 @@
 			  "type": "checkbox",
 			  "value": false,
 			  "label": {
-				"en": "Allow HVAC Eco mode override?",
-				"nl": "HVAC Eco modus overschrijven toestaan?"
+				"en": "Allow HVAC Eco mode override",
+				"nl": "HVAC Eco modus overschrijven toestaan"
 			  },
 			  "hint": {
-				"en": "If HVAC Eco Mode is active, setting a target temperature is not allowed.\n\nIf HVAC Eco Mode is active, can it be overridden so that the temperature can still be set?",
-				"nl": "Indien HVAC Eco modus actief is, is het instellen van een doel temperatuur niet toegestaan.\n\nIndien HVAC Eco modus actief is, kan deze dan vooraf worden overschreven zodat de temperatuur toch kan worden ingesteld?"
+				"en": "If HVAC Eco Mode is active, setting a target temperature is not allowed.\n\nThis setting allows Homey to override the Eco mode when adjusting the target temperature when in Eco mode.",
+				"nl": "Indien HVAC Eco modus actief is, is het instellen van een doel temperatuur niet toegestaan.\n\nDeze instelling laat Homey, indien HVAC Eco modus actief is deze overschrijven zodat de temperatuur toch kan worden ingesteld."
 			  }
 			},
 			{
@@ -127,8 +127,8 @@
 				"nl": "Altijd overschrijven met modus"
 			  },
 			  "hint": {
-				"en": "Caution: All HVAC modes are displayed, but thermostat settings may not support some modes!",
-				"nl": "Let op: alle HVAC modi worden weergegeven, maar thermostaat instellingen ondersteunen wellicht sommige modi niet!"
+				"en": "Caution: All HVAC modes are displayed, even though your thermostat may not support some modes.",
+				"nl": "Let op: alle HVAC modi worden weergegeven, maar het kan zijn dat je thermostaat bepaalde modi niet ondersteund."
 			  },
 			  "values": [
 				{

--- a/drivers/nest_thermostat/driver.js
+++ b/drivers/nest_thermostat/driver.js
@@ -123,47 +123,41 @@ module.exports.capabilities = {
 		set: (deviceData, temperature, callback) => {
 			if (deviceData instanceof Error) return callback(deviceData);
 
-			module.exports.getSettings(deviceData, function(err, settings) {
-				if (err) {
-					// Fallback to defaults
-					settings = { eco_override_allow: false,	eco_override_by: 'heat' };
+			// Get device data
+			const thermostat = getDevice(deviceData);
+			if (thermostat && thermostat.hasOwnProperty('client')) {
+
+				// Determine if mode is Eco and if it may be overridden
+				if (thermostat.client.hasOwnProperty('hvac_mode') &&
+					thermostat.client.hvac_mode === 'eco' &&
+					thermostat.hasOwnProperty('settings') &&
+					thermostat.settings.eco_override_allow === true &&
+					['heat', 'cool', 'heat-cool'].indexOf(thermostat.settings.eco_override_by) >= 0) {
+
+					thermostat.client.setHvacMode(thermostat.settings.eco_override_by)
+						.then(() => {
+							// Override succeeded: re-attempt to set target temperature
+							return module.exports.capabilities.target_temperature.set(deviceData, temperature, callback);
+						})
+						.catch((err) => {
+							// Override failed
+							const errOverride = __('error.hvac_mode_eco_override_failed', { name: thermostat.client.name_long || '' }) + err;
+							Homey.app.registerLogItem({ msg: errOverride, timestamp: new Date() });
+							return callback(errOverride);
+						});
+				} else {
+					// Fix temperature range
+					temperature = Math.round(temperature * 2) / 2;
+
+					thermostat.client.setTargetTemperature(temperature)
+						.then(() => callback(null, temperature))
+						.catch(err => {
+							console.error(err);
+							Homey.app.registerLogItem({ msg: err, timestamp: new Date() });
+							return callback(err);
+						});
 				}
-
-				// Get device data
-				const thermostat = getDevice(deviceData);
-				if (thermostat && thermostat.hasOwnProperty('client')) {
-
-					// Determine if mode is Eco and if it may be overridden
-					if (thermostat.client.hasOwnProperty('hvac_mode') &&
-						thermostat.client.hvac_mode === 'eco' &&
-						settings.eco_override_allow === true &&
-						['heat', 'cool', 'heat-cool'].indexOf(settings.eco_override_by) >= 0) {
-
-						thermostat.client.setHvacMode(settings.eco_override_by)
-							.then(() => {
-								// Override succeeded: re-attempt to set target temperature
-								return module.exports.capabilities.target_temperature.set(deviceData, temperature, callback);
-							})
-							.catch((err) => {
-								// Override failed
-								const errOverride = __('error.hvac_mode_eco_override_failed', { name: thermostat.client.name_long || '' }) + err;
-								Homey.app.registerLogItem({ msg: errOverride, timestamp: new Date() });
-								return callback(errOverride);
-							});
-					} else {
-						// Fix temperature range
-						temperature = Math.round(temperature * 2) / 2;
-
-						thermostat.client.setTargetTemperature(temperature)
-							.then(() => callback(null, temperature))
-							.catch(err => {
-								console.error(err);
-								Homey.app.registerLogItem({ msg: err, timestamp: new Date() });
-								return callback(err);
-							});
-					}
-				} else return callback('No Nest client found');
-			});
+			} else return callback('No Nest client found');
 		},
 	},
 
@@ -228,6 +222,24 @@ module.exports.deleted = (deviceData) => {
 };
 
 /**
+ * Store new settings in device object when the user has changed the device's settings in Homey
+ * @param deviceData
+ * @param newSettings
+ * @param oldSettings
+ * @param changedKeys
+ * @param callback
+ */
+module.exports.settings = function(deviceData, newSettings, oldSettings, changedKeys, callback) {
+	// Get device data
+	const thermostat = getDevice(deviceData);
+	if (thermostat) {
+		thermostat.settings = newSettings;
+		return callback(null, true);
+	}
+	return callback('Could not find device');
+};
+
+/**
  * Initialize device, setup client, and event listeners.
  * @param deviceData
  * @returns {*}
@@ -272,14 +284,22 @@ function initDevice(deviceData) {
 			module.exports.setUnavailable(deviceData, __('removed_externally'));
 		});
 
-	// Store it
-	const device = getDevice(deviceData);
-	if (device) {
-		device.client = client;
-		device.initialized = true;
-	} else devices.push({ data: deviceData, client, initialized: true });
+	module.exports.getSettings(deviceData, (err, settings) => {
+		if (err) {
+			// Fallback to defaults
+			settings = { eco_override_allow: false, eco_override_by: 'heat' };
+		}
 
-	module.exports.setAvailable(deviceData);
+		// Store it
+		const device = getDevice(deviceData);
+		if (device) {
+			device.client = client;
+			device.initialized = true;
+			device.settings = settings;
+		} else devices.push({ data: deviceData, client, initialized: true, settings });
+
+		module.exports.setAvailable(deviceData);
+	});
 }
 
 /**

--- a/locales/en.json
+++ b/locales/en.json
@@ -39,6 +39,7 @@
     "hvac_mode_cool_unsupported": "(__name__) HVAC mode cooling is unsupported",
     "hvac_mode_heat_unsupported": "(__name__) HVAC mode heating is unsupported",
     "hvac_mode_eco_unsupported": "(__name__) HVAC mode eco is unsupported",
+    "hvac_mode_eco_override_failed": "(__name__) HVAC mode eco override failed: ",
     "unknown": "(__name__) Failed to set target temperature to __temp__, error: __error__"
   },
   "pair": {

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -39,6 +39,7 @@
 		"hvac_mode_cool_unsupported": "HVAC koel modus was niet beschikbaar",
 		"hvac_mode_heat_unsupported": "HVAC verwarm modus was niet beschikbaar",
 		"hvac_mode_eco_unsupported": "HVAC eco modus was niet beschikbaar",
+		"hvac_mode_eco_override_failed": "HVAC eco modus overschrijven was mislukt: ",
 		"unknown": "(__name__) Kon doeltemperatuur niet aanpassen naar __temp__, error: __error__"
 	},
 	"pair": {

--- a/nest.js
+++ b/nest.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const semver = require('semver');
 const EventEmitter = require('events');
 const Firebase = require('firebase');
 const request = require('request');


### PR DESCRIPTION
If HVAC Eco Mode is active, setting a target temperature is not allowed by the Nest API.
I added settings in Homey for all Nest Thermostat device tiles. The settings page allows the user to enable the "HVAC Eco mode override" setting.

When enabled, the specified "override mode" (e.g. "heating") will be set prior to setting the temperature.
When disabled, the behaviour obviously remains as before.

_Use case:_
When someone sets the HVAC mode to Eco when leaving the house, he/she can use Homey's mobile app to set a target temperature before returning home (to a cozy heated environment).
Previously this would have failed since the temperature could not be set in Eco mode. Now the mode is switched and the temperature can safely be set.

Same goes for setting the target temperature using speech input, without leaving the couch to "remove" Eco mode ;)